### PR TITLE
Added convert encoding support

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -8,3 +8,5 @@ $db_host = 'localhost';
 $xbase_dir = '/home/user/path/to/dbf/files ';
 
 $die_on_mysql_error = false; // when investigating errors, set this to true
+
+$from_encoding=""; //Encoding of database, e.g. CP866 or empty, if convert is not required

--- a/dbf-import.php
+++ b/dbf-import.php
@@ -133,6 +133,8 @@ function import_dbf($db_path, $tbl) {
 		$val = implode(",",$line);
 		$col = implode(",",$fields);
 
+        if($GLOBALS['from_encoding']!="")$val = mb_convert_encoding($val, 'UTF-8', $GLOBALS['from_encoding'] );
+
 		$sql = "INSERT INTO `$tbl` ($col) VALUES ($val)\n";
 		// print_r ("$sql");
 		if ($conn->query("$sql") === TRUE) {
@@ -171,6 +173,7 @@ function import_dbf_to_mysql( $table, $dbf_path, $fpt_path ) {
                 continue;
             }
             $val = str_replace( "'", "", $val );
+            if($GLOBALS['from_encoding']!="")$val = mb_convert_encoding($val, 'UTF-8', $GLOBALS['from_encoding'] );
             $a = $a + 1;
             if ( $a == 1 ) {
                 $sql1 .="`$key`";


### PR DESCRIPTION
This convertation of encoding especially needed for convert address database of Russian address (http://fias.nalog.ru/Updates.aspx) from CP866 to UTF-8, and for other old databases in CP866
