### PR TITLE
Update dbf-import.php to include Memo.php

### DIFF
--- a/dbf-import.php
+++ b/dbf-import.php
@@ -5,6 +5,7 @@
 @include "classes/XBase/Table.php";
 @include "classes/XBase/Column.php";
 @include "classes/XBase/Record.php";
+@include "classes/XBase/Memo.php";
 @include "classes/DBFhandler.php";
 
 use XBase\Table;


### PR DESCRIPTION
Fixes this error:
```
PHP Fatal error:  Uncaught Error: Class 'XBase\Memo' not found in ~/php-xbase/src/XBase/Table.php:35
Stack trace:
#0 ~/DBFToMySQL/dbf-import.php(42): XBase\Table->__construct('~/dbffile...')
#1 ~/DBFToMySQL/dbf-import.php(24): dbftomysql('DBFFILE.dbf')
#2 {main}
  thrown in ~/php-xbase/src/XBase/Table.php on line 35
```